### PR TITLE
Fix data type conversion in prediction error calculation

### DIFF
--- a/buoy_data/ml/forecaster.py
+++ b/buoy_data/ml/forecaster.py
@@ -252,6 +252,13 @@ class BuoyForecaster:
         if include_current:
             current_heights = current_data[['buoy_id', 'wave_height_m']].copy()
             current_heights.columns = ['buoy_id', 'actual_wave_height_m']
+
+            # Convert to numeric to handle any string values
+            current_heights['actual_wave_height_m'] = pd.to_numeric(
+                current_heights['actual_wave_height_m'],
+                errors='coerce'
+            )
+
             results = results.merge(current_heights, on='buoy_id', how='left')
 
             # Calculate errors where actual data exists


### PR DESCRIPTION
- Convert actual_wave_height_m to numeric before calculating errors
- Handle string values ('', 'MM') in wave height data
- Prevents TypeError when subtracting string from float

This resolves the error when comparing predictions with actual readings that contain non-numeric values from NOAA data feeds.