### PR TITLE
Fix spatial info retrieval in forecast_between_buoys

### DIFF
--- a/buoy_data/ml/forecaster.py
+++ b/buoy_data/ml/forecaster.py
@@ -268,9 +268,12 @@ class BuoyForecaster:
                 results.loc[mask, 'actual_wave_height_m']
             )
 
-        # Add spatial info
-        spatial_info = current_data[['buoy_id', 'latitude', 'longitude']].copy()
-        results = results.merge(spatial_info, on='buoy_id', how='left')
+        # Add spatial info (from prepared_data which has lat/lon added by feature engineering)
+        if 'latitude' in prepared_data.columns and 'longitude' in prepared_data.columns:
+            spatial_info = prepared_data[['buoy_id', 'latitude', 'longitude']].copy()
+            # Remove duplicates in case there are multiple rows per buoy
+            spatial_info = spatial_info.drop_duplicates(subset=['buoy_id'])
+            results = results.merge(spatial_info, on='buoy_id', how='left')
 
         logger.info(f"Generated forecasts for {len(results)} buoys")
 


### PR DESCRIPTION
- Get latitude/longitude from prepared_data instead of current_data
- Add check to ensure spatial columns exist before merging
- Handle duplicate buoy_id rows when adding spatial info

The lat/lon columns are added by feature engineering, not data collection, so they must be retrieved from prepared_data.