### PR TITLE
Add automatic station discovery and region filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,18 +534,27 @@ python train_model.py [OPTIONS]
 
 **Options:**
 - `--buoys BUOY_ID [BUOY_ID ...]` - List of buoy station IDs (default: 44017 44008 44013 44025)
+- `--all-stations` - Use all available stations from NOAA realtime2 directory
+- `--region {northeast,southeast,caribbean,pacific,greatlakes,hawaii}` - Filter by region (use with --all-stations)
 - `--days N` - Number of days of historical data (default: 7)
 - `--model-type {random_forest,gradient_boosting}` - Model type (default: random_forest)
 - `--output PATH` - Path to save trained model (default: models/wave_predictor.pkl)
 - `--db CONNECTION_STRING` - Database connection string (default: sqlite:///buoy_ml_data.db)
 
-**Example:**
+**Examples:**
 ```bash
+# Train with specific buoys
 python train_model.py \
     --buoys 44017 44008 44013 44025 \
     --days 7 \
     --model-type random_forest \
     --output models/my_model.pkl
+
+# Train with all available stations
+python train_model.py --all-stations --days 7
+
+# Train with all Northeast Atlantic stations
+python train_model.py --all-stations --region northeast --days 7
 ```
 
 #### train_model_advanced.py
@@ -559,6 +568,8 @@ python train_model_advanced.py [OPTIONS]
 
 **Options:**
 - `--buoys BUOY_ID [BUOY_ID ...]` - List of buoy station IDs (default: 44017 44008 44013 44025 44065 44066)
+- `--all-stations` - Use all available stations from NOAA realtime2 directory
+- `--region {northeast,southeast,caribbean,pacific,greatlakes,hawaii}` - Filter by region (use with --all-stations)
 - `--days N` - Number of days of historical data (default: 14, recommended: 21+)
 - `--tune` - Enable hyperparameter tuning with RandomizedSearchCV (slower but better)
 - `--model-type {random_forest,gradient_boosting}` - Model type (default: random_forest)
@@ -578,6 +589,12 @@ python train_model_advanced.py \
     --buoys 44017 44008 44013 \
     --days 14 \
     --output models/northeast_predictor.pkl
+
+# Train with ALL available stations (comprehensive model)
+python train_model_advanced.py --all-stations --days 14
+
+# Train with all Pacific region stations
+python train_model_advanced.py --all-stations --region pacific --days 14 --tune
 ```
 
 **Performance Tips:**
@@ -642,6 +659,58 @@ python predict.py --buoys 44017 44008 44013 --mode forecast
 # Regional summary
 python predict.py --buoys 44017 44008 44013 44025 --mode summary
 ```
+
+### Station Discovery and Region Filtering
+
+The package includes utilities to automatically discover all available buoy stations from NOAA's real-time data feeds.
+
+#### Using Python API
+
+```python
+from buoy_data import get_available_stations, filter_stations_by_region
+
+# Get all available stations
+all_stations = get_available_stations()
+print(f"Found {len(all_stations)} active stations")
+
+# Filter by region
+northeast = filter_stations_by_region(all_stations, 'northeast')
+pacific = filter_stations_by_region(all_stations, 'pacific')
+```
+
+#### Region Mapping
+
+Station IDs use prefixes to indicate geographic regions:
+
+- **northeast** (44xxx) - Northeast North Atlantic (New England, Mid-Atlantic)
+- **southeast** (42xxx) - Southeast North Atlantic (South Atlantic Coast)
+- **caribbean** (41xxx) - Southwest North Atlantic (Caribbean, Gulf of Mexico)
+- **pacific** (46xxx) - Northeast Pacific (West Coast, Alaska)
+- **greatlakes** (45xxx) - Great Lakes
+- **hawaii** (51xxx) - Southwest Pacific (Hawaiian Islands)
+
+#### Training with All Stations
+
+Using `--all-stations` automatically trains on all buoys with available data:
+
+```bash
+# Train on ALL available stations (200+ buoys)
+python train_model_advanced.py --all-stations --days 14
+
+# Train on all Northeast stations (40+ buoys)
+python train_model_advanced.py --all-stations --region northeast --days 14
+```
+
+**Benefits:**
+- Maximum spatial coverage for better predictions
+- No need to manually track active stations
+- Automatically adapts to station availability
+- Better model generalization across regions
+
+**Considerations:**
+- More stations = longer training time
+- Some stations may have incomplete data (handled gracefully)
+- Regional models often perform better than global models
 
 ### Common Buoy Stations (US East Coast)
 

--- a/buoy_data/__init__.py
+++ b/buoy_data/__init__.py
@@ -10,6 +10,7 @@ from .buoy_real_time import BuoyRealTime
 from .buoy_hourly import BuoyHourly
 from .station import Station, BuoyDataStation
 from .database import BuoyDataDB
+from .utils import get_available_stations, filter_stations_by_region, validate_station_ids
 
 __version__ = "1.0.0"
 __author__ = "C.J. Walsh"
@@ -20,4 +21,7 @@ __all__ = [
     "Station",
     "BuoyDataStation",
     "BuoyDataDB",
+    "get_available_stations",
+    "filter_stations_by_region",
+    "validate_station_ids",
 ]

--- a/buoy_data/utils.py
+++ b/buoy_data/utils.py
@@ -1,0 +1,144 @@
+"""Utility functions for buoy data operations."""
+
+import re
+import logging
+import requests
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def get_available_stations(timeout: int = 10) -> List[str]:
+    """
+    Fetch list of all available buoy stations from NOAA's realtime2 directory.
+
+    This function scrapes the NOAA realtime2 directory to find all active buoy
+    stations that currently have data available.
+
+    Args:
+        timeout: Request timeout in seconds (default: 10)
+
+    Returns:
+        List of station IDs (e.g., ['44017', '44008', '44013'])
+
+    Raises:
+        requests.RequestException: If the request fails
+
+    Example:
+        >>> stations = get_available_stations()
+        >>> print(f"Found {len(stations)} active stations")
+        >>> print(stations[:5])  # Show first 5
+    """
+    url = 'https://www.ndbc.noaa.gov/data/realtime2/'
+
+    logger.info(f"Fetching available stations from {url}")
+
+    try:
+        response = requests.get(url, timeout=timeout)
+        response.raise_for_status()
+
+        # Parse HTML to extract .txt file links
+        # Pattern matches links like: <a href="44017.txt">
+        pattern = r'<a href="([^"]+\.txt)">'
+        matches = re.findall(pattern, response.text)
+
+        # Extract station IDs (filename without .txt extension)
+        stations = []
+        for match in matches:
+            # Remove .txt extension
+            station_id = match.replace('.txt', '')
+
+            # Filter out non-buoy files (like .drift.txt, .spec.txt, etc.)
+            # Valid station IDs are typically 5 characters (numeric or alphanumeric)
+            if '.' not in station_id and len(station_id) <= 6:
+                stations.append(station_id)
+
+        # Sort for consistency
+        stations.sort()
+
+        logger.info(f"Found {len(stations)} available stations")
+
+        return stations
+
+    except requests.RequestException as e:
+        logger.error(f"Failed to fetch available stations: {e}")
+        raise
+
+
+def filter_stations_by_region(
+    stations: List[str],
+    region: Optional[str] = None
+) -> List[str]:
+    """
+    Filter stations by geographic region based on station ID prefix.
+
+    Station ID prefixes indicate geographic regions:
+    - 41xxx: Southwest North Atlantic (Caribbean)
+    - 42xxx: Southeast North Atlantic
+    - 44xxx: Northeast North Atlantic
+    - 45xxx: Great Lakes
+    - 46xxx: Northeast Pacific
+    - 51xxx: Southwest Pacific (Hawaii)
+
+    Args:
+        stations: List of station IDs
+        region: Region code ('northeast', 'southeast', 'caribbean', 'pacific',
+                'greatlakes', 'hawaii') or None for all
+
+    Returns:
+        Filtered list of station IDs
+
+    Example:
+        >>> all_stations = get_available_stations()
+        >>> ne_stations = filter_stations_by_region(all_stations, 'northeast')
+        >>> print(f"Found {len(ne_stations)} Northeast Atlantic stations")
+    """
+    if not region:
+        return stations
+
+    region_prefixes = {
+        'caribbean': ['41'],
+        'southeast': ['42'],
+        'northeast': ['44'],
+        'greatlakes': ['45'],
+        'pacific': ['46'],
+        'hawaii': ['51']
+    }
+
+    region_lower = region.lower()
+
+    if region_lower not in region_prefixes:
+        logger.warning(f"Unknown region '{region}'. Valid regions: {list(region_prefixes.keys())}")
+        return stations
+
+    prefixes = region_prefixes[region_lower]
+    filtered = [s for s in stations if any(s.startswith(p) for p in prefixes)]
+
+    logger.info(f"Filtered to {len(filtered)} stations in {region} region")
+
+    return filtered
+
+
+def validate_station_ids(station_ids: List[str]) -> List[str]:
+    """
+    Validate and clean a list of station IDs.
+
+    Args:
+        station_ids: List of station IDs to validate
+
+    Returns:
+        List of valid station IDs
+    """
+    valid_stations = []
+
+    for station_id in station_ids:
+        # Clean up whitespace
+        station_id = station_id.strip()
+
+        # Basic validation
+        if station_id and len(station_id) <= 6:
+            valid_stations.append(station_id)
+        else:
+            logger.warning(f"Skipping invalid station ID: {station_id}")
+
+    return valid_stations

--- a/test_station_discovery.py
+++ b/test_station_discovery.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+"""Test script to verify station discovery functionality."""
+
+from buoy_data import get_available_stations, filter_stations_by_region
+
+print("="*70)
+print("BUOY STATION DISCOVERY TEST")
+print("="*70)
+
+# Test 1: Get all available stations
+print("\nTest 1: Fetching all available stations...")
+try:
+    all_stations = get_available_stations()
+    print(f"✓ Found {len(all_stations)} active stations")
+    print(f"First 10: {all_stations[:10]}")
+except Exception as e:
+    print(f"✗ Error: {e}")
+
+# Test 2: Filter by Northeast region
+print("\nTest 2: Filtering Northeast stations...")
+try:
+    northeast = filter_stations_by_region(all_stations, 'northeast')
+    print(f"✓ Found {len(northeast)} Northeast stations")
+    print(f"Northeast stations: {northeast[:10]}")
+except Exception as e:
+    print(f"✗ Error: {e}")
+
+# Test 3: Filter by Pacific region
+print("\nTest 3: Filtering Pacific stations...")
+try:
+    pacific = filter_stations_by_region(all_stations, 'pacific')
+    print(f"✓ Found {len(pacific)} Pacific stations")
+    print(f"Pacific stations: {pacific[:10]}")
+except Exception as e:
+    print(f"✗ Error: {e}")
+
+# Test 4: Filter by Caribbean region
+print("\nTest 4: Filtering Caribbean stations...")
+try:
+    caribbean = filter_stations_by_region(all_stations, 'caribbean')
+    print(f"✓ Found {len(caribbean)} Caribbean stations")
+    print(f"Caribbean stations: {caribbean[:10]}")
+except Exception as e:
+    print(f"✗ Error: {e}")
+
+print("\n" + "="*70)
+print("All tests completed!")
+print("="*70)

--- a/train_model.py
+++ b/train_model.py
@@ -5,6 +5,7 @@ import argparse
 import logging
 
 from buoy_data.ml import BuoyForecaster
+from buoy_data.utils import get_available_stations, filter_stations_by_region
 
 logging.basicConfig(
     level=logging.INFO,
@@ -20,8 +21,19 @@ def main():
     parser.add_argument(
         '--buoys',
         nargs='+',
-        default=['44017', '44008', '44013', '44025'],
+        default=None,
         help='List of buoy station IDs to train on'
+    )
+    parser.add_argument(
+        '--all-stations',
+        action='store_true',
+        help='Use all available stations from NOAA realtime2 directory'
+    )
+    parser.add_argument(
+        '--region',
+        type=str,
+        choices=['northeast', 'southeast', 'caribbean', 'pacific', 'greatlakes', 'hawaii'],
+        help='Filter stations by region (use with --all-stations)'
     )
     parser.add_argument(
         '--days',
@@ -49,6 +61,26 @@ def main():
     )
 
     args = parser.parse_args()
+
+    # Determine which buoys to use
+    if args.all_stations:
+        try:
+            buoys = get_available_stations()
+            if args.region:
+                buoys = filter_stations_by_region(buoys, args.region)
+            logger.info(f"Using all available stations: {len(buoys)} buoys")
+        except Exception as e:
+            logger.error(f"Failed to fetch available stations: {e}")
+            logger.info("Falling back to default buoys")
+            buoys = ['44017', '44008', '44013', '44025']
+    elif args.buoys:
+        buoys = args.buoys
+    else:
+        # Default buoys if neither flag is specified
+        buoys = ['44017', '44008', '44013', '44025']
+        logger.info("Using default buoys (use --all-stations to train on all available stations)")
+
+    args.buoys = buoys
 
     logger.info("="*60)
     logger.info("BUOY WAVE HEIGHT FORECASTING - MODEL TRAINING")


### PR DESCRIPTION
- Add buoy_data/utils.py with station discovery utilities
  - get_available_stations(): Fetch all active stations from NOAA realtime2
  - filter_stations_by_region(): Filter by geographic region
  - validate_station_ids(): Validate station ID format
- Update train_model.py with --all-stations and --region flags
- Update train_model_advanced.py with --all-stations and --region flags
- Export utilities in buoy_data/__init__.py
- Add comprehensive documentation to README
  - Station Discovery and Region Filtering section
  - Region mapping (northeast, southeast, caribbean, pacific, greatlakes, hawaii)
  - Training examples with --all-stations flag
  - Benefits and considerations
- Add test_station_discovery.py for testing functionality

This allows training on all available NOAA stations without manual ID entry:
  python train_model_advanced.py --all-stations --days 14
  python train_model_advanced.py --all-stations --region northeast --days 14