### PR TITLE
Fix numeric conversion in split_features_target

### DIFF
--- a/buoy_data/ml/feature_engineering.py
+++ b/buoy_data/ml/feature_engineering.py
@@ -368,6 +368,10 @@ class FeatureEngineer:
 
         X = df[feature_cols].copy()
 
+        # Convert all columns to numeric (handle any remaining strings)
+        for col in X.columns:
+            X[col] = pd.to_numeric(X[col], errors='coerce')
+
         # Fill NaN values
         X = X.fillna(X.median())
 


### PR DESCRIPTION
- Convert all feature columns to numeric before computing median
- Handles remaining empty strings in data with pd.to_numeric(errors='coerce')
- Fixes TypeError: Cannot convert to numeric when filling NaN values