### PR TITLE
Add data caching to minimize remote downloads

### DIFF
--- a/buoy_data/ml/forecaster.py
+++ b/buoy_data/ml/forecaster.py
@@ -67,7 +67,8 @@ class BuoyForecaster:
         buoy_ids: List[str],
         days_back: int = 7,
         model_type: str = "random_forest",
-        save_path: Optional[str] = None
+        save_path: Optional[str] = None,
+        use_cache: bool = False
     ) -> Dict[str, float]:
         """
         Train a new forecasting model.
@@ -77,6 +78,7 @@ class BuoyForecaster:
             days_back: Number of days of historical data to collect
             model_type: Type of model ('random_forest' or 'gradient_boosting')
             save_path: Optional path to save trained model
+            use_cache: If True, use cached data from database (default: False)
 
         Returns:
             Dictionary of training metrics
@@ -87,7 +89,8 @@ class BuoyForecaster:
         logger.info("Collecting training data...")
         raw_data = self.data_collector.collect_training_dataset(
             buoy_ids,
-            days_back=days_back
+            days_back=days_back,
+            use_cache=use_cache
         )
 
         if raw_data.empty:

--- a/download_data.py
+++ b/download_data.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+"""Download and cache buoy data for offline training."""
+
+import argparse
+import logging
+
+from buoy_data.ml import DataCollector
+from buoy_data.utils import get_available_stations, filter_stations_by_region
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Download and cache buoy data for offline training'
+    )
+    parser.add_argument(
+        '--buoys',
+        nargs='+',
+        default=None,
+        help='List of buoy station IDs to download'
+    )
+    parser.add_argument(
+        '--all-stations',
+        action='store_true',
+        help='Download data from all available stations'
+    )
+    parser.add_argument(
+        '--region',
+        type=str,
+        choices=['northeast', 'southeast', 'caribbean', 'pacific', 'greatlakes', 'hawaii'],
+        help='Filter stations by region (use with --all-stations)'
+    )
+    parser.add_argument(
+        '--days',
+        type=int,
+        default=14,
+        help='Number of days of historical data to download (default: 14)'
+    )
+    parser.add_argument(
+        '--db',
+        type=str,
+        default='sqlite:///buoy_ml_data.db',
+        help='Database connection string'
+    )
+
+    args = parser.parse_args()
+
+    # Determine which buoys to download
+    if args.all_stations:
+        try:
+            buoys = get_available_stations()
+            if args.region:
+                buoys = filter_stations_by_region(buoys, args.region)
+            logger.info(f"Downloading data from all available stations: {len(buoys)} buoys")
+        except Exception as e:
+            logger.error(f"Failed to fetch available stations: {e}")
+            return 1
+    elif args.buoys:
+        buoys = args.buoys
+    else:
+        # Default buoys if neither flag is specified
+        buoys = ['44017', '44008', '44013', '44025', '44065', '44066']
+        logger.info("Using default buoys (use --all-stations to download from all)")
+
+    logger.info("="*70)
+    logger.info("BUOY DATA DOWNLOAD AND CACHING")
+    logger.info("="*70)
+    logger.info(f"Buoy stations: {len(buoys)} buoys")
+    logger.info(f"Days of data: {args.days}")
+    logger.info(f"Database: {args.db}")
+    logger.info("="*70)
+
+    try:
+        # Initialize data collector
+        collector = DataCollector(db_path=args.db)
+
+        # Download and cache data (use_cache=False forces download)
+        logger.info("\nDownloading data from NOAA...")
+        data = collector.collect_training_dataset(
+            buoys,
+            days_back=args.days,
+            use_cache=False,  # Always download fresh data
+            save_to_db=True   # Save to database
+        )
+
+        if data.empty:
+            logger.warning("No data was collected")
+            return 1
+
+        logger.info("\n" + "="*70)
+        logger.info("DOWNLOAD COMPLETE")
+        logger.info("="*70)
+        logger.info(f"Total readings downloaded: {len(data)}")
+        logger.info(f"Buoys with data: {data['buoy_id'].nunique()}")
+        logger.info(f"\nData cached in: {args.db}")
+        logger.info("\nYou can now train models with --use-cache flag:")
+        logger.info(f"  python train_model.py --buoys {' '.join(buoys[:3])} --use-cache")
+        logger.info("="*70)
+
+        collector.close()
+        return 0
+
+    except Exception as e:
+        logger.error(f"Download failed: {e}", exc_info=True)
+        return 1
+
+
+if __name__ == '__main__':
+    exit(main())

--- a/train_model.py
+++ b/train_model.py
@@ -59,6 +59,11 @@ def main():
         default='sqlite:///buoy_ml_data.db',
         help='Database connection string'
     )
+    parser.add_argument(
+        '--use-cache',
+        action='store_true',
+        help='Use cached data from database instead of re-downloading'
+    )
 
     args = parser.parse_args()
 
@@ -99,7 +104,8 @@ def main():
                 buoy_ids=args.buoys,
                 days_back=args.days,
                 model_type=args.model_type,
-                save_path=args.output
+                save_path=args.output,
+                use_cache=args.use_cache
             )
 
             logger.info("\n" + "="*60)

--- a/train_model_advanced.py
+++ b/train_model_advanced.py
@@ -116,6 +116,11 @@ def main():
         default='sqlite:///buoy_ml_data.db',
         help='Database connection string'
     )
+    parser.add_argument(
+        '--use-cache',
+        action='store_true',
+        help='Use cached data from database instead of re-downloading'
+    )
 
     args = parser.parse_args()
 
@@ -157,7 +162,8 @@ def main():
             logger.info(f"\nCollecting training data from {len(args.buoys)} buoys...")
             raw_data = forecaster.data_collector.collect_training_dataset(
                 args.buoys,
-                days_back=args.days
+                days_back=args.days,
+                use_cache=args.use_cache
             )
 
             if raw_data.empty:


### PR DESCRIPTION
- Add use_cache parameter to DataCollector.collect_training_dataset()
  - Checks database for existing data before downloading
  - Falls back to remote download if insufficient cached data
  - Automatically saves downloaded data to database
- Add --use-cache flag to train_model.py and train_model_advanced.py
- Add download_data.py script for pre-downloading data
  - Supports --all-stations and --region flags
  - Downloads and caches data for offline training
- Update BuoyForecaster.train() to support use_cache parameter

Benefits:
- Significantly faster training when using cached data
- Reduces load on NOAA servers
- Enables offline training after initial data download
- Automatic data persistence in SQLite database

Usage:
  # Download data once python download_data.py --buoys 44017 44008 44013 --days 14

  # Train using cached data (no remote download) python train_model.py --buoys 44017 44008 44013 --use-cache